### PR TITLE
Ajoute un script qui aide à vérifier la validité des certificats

### DIFF
--- a/check_certificates/check
+++ b/check_certificates/check
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/get_validity"
+
+read -r -d '' DSC_domains <<__EOF__
+demainspecialiste.cyber.gouv.fr
+www.demainspecialistecyber.fr
+demainspecialistecyber.fr
+__EOF__
+
+read -r -d '' MAC_domains <<__EOF__
+www.monaidecyber.ssi.gouv.fr
+monaidecyber.ssi.gouv.fr
+www.monaide.cyber.gouv.fr
+monaide.cyber.gouv.fr
+__EOF__
+
+read -r -d '' MSC_domains <<__EOF__
+messervices.cyber.gouv.fr
+__EOF__
+
+read -r -d '' MSS_domains <<__EOF__
+www.monservicesecurise.ssi.gouv.fr
+monservicesecurise.ssi.gouv.fr
+www.monservicesecurise.cyber.gouv.fr
+monservicesecurise.cyber.gouv.fr
+__EOF__
+
+read -r -d '' NIS2_domains <<__EOF__
+www.monespacenis2.cyber.gouv.fr
+monespacenis2.cyber.gouv.fr
+__EOF__
+
+result=$(mktemp)
+for ds in "DSC_domains" "MAC_domains" "MSC_domains" "MSS_domains" "NIS2_domains"; do
+  echo ${ds:0:-8} >> $result
+  get_certificate_validity_for_domains "${!ds}" >> $result
+done
+column -t $result

--- a/check_certificates/get_validity
+++ b/check_certificates/get_validity
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+declare -F openssl_connect > /dev/null || openssl_connect() {
+  local endpoint="${1}:443"
+  openssl s_client -connect "$endpoint" </dev/null 2>/dev/null
+}
+
+get_certificate_validity_for_domain() {
+  openssl_connect "$1" \
+    | openssl x509 -inform pem -text \
+    | jc --x509-cert \
+    | jq -r '.[0].tbs_certificate.validity | [.not_before, .not_after] | map(strftime("%d/%m/%Y")) | "\(.[0]) -> \(.[1])"'
+}
+
+get_certificate_validity_for_domains() {
+  for d in $1; do
+    echo -en "$d "
+    get_certificate_validity_for_domain "$d"
+  done
+}

--- a/check_certificates/tests/fixtures/monservicesecurise.cyber.gouv.fr.pem
+++ b/check_certificates/tests/fixtures/monservicesecurise.cyber.gouv.fr.pem
@@ -1,0 +1,105 @@
+CONNECTED(00000003)
+---
+Certificate chain
+ 0 s:CN=monservicesecurise.cyber.gouv.fr
+   i:C=FR, O=Gandi SAS, CN=GandiCert
+   a:PKEY: RSA, 2048 (bit); sigalg: sha256WithRSAEncryption
+   v:NotBefore: Feb 26 00:00:00 2026 GMT; NotAfter: Sep 12 23:59:59 2026 GMT
+ 1 s:C=FR, O=Gandi SAS, CN=GandiCert
+   i:C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Global Root G2
+   a:PKEY: RSA, 4096 (bit); sigalg: sha256WithRSAEncryption
+   v:NotBefore: Apr 17 00:00:00 2024 GMT; NotAfter: Apr 16 23:59:59 2034 GMT
+---
+Server certificate
+-----BEGIN CERTIFICATE-----
+MIIHkzCCBXugAwIBAgIQDOHKFvcU63v8RiLZyitm+TANBgkqhkiG9w0BAQsFADA1
+MQswCQYDVQQGEwJGUjESMBAGA1UEChMJR2FuZGkgU0FTMRIwEAYDVQQDEwlHYW5k
+aUNlcnQwHhcNMjYwMjI2MDAwMDAwWhcNMjYwOTEyMjM1OTU5WjArMSkwJwYDVQQD
+EyBtb25zZXJ2aWNlc2VjdXJpc2UuY3liZXIuZ291di5mcjCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBAJ+5cZWsfuUBH4w3Mdrlf2itsk3ErsAGHXTrpUdk
+JsvnyuQHpIu6ZQ51Y5ktBqoMvW8ClQPiXNoec8YWD9ehhWOo1vFebgORTmky3HYP
+ewO59pk3QpcKnQ5WbU4zrVHbyfD+09B2kySz/izZ1wnbqPkxzq0WL7CDnssMx20O
+1sn2LWbEti8PCw1S9xYBl2cgmkjlZOMLS5GYwy2NAx600PMbivwiE2Ff7fwa0O9q
+HZtVv2KbsMmQ6Q4Utm3cHv1AzoCbY8itNY8er/V9rFCHXulGrT3zERx/UVMEn2zJ
+OV/Z4IZgud+BuNtYbj82En0bytBwaDz2kzf0Jw6W29IGxC8CAwEAAaOCA6cwggOj
+MB8GA1UdIwQYMBaAFLq7RohF7N1aKxjF0U7s4zwGUlOsMB0GA1UdDgQWBBSTVyt/
+JN0io66CUw9/sz/Tls5pujCBlwYDVR0RBIGPMIGMgiBtb25zZXJ2aWNlc2VjdXJp
+c2UuY3liZXIuZ291di5mcoIebW9uc2VydmljZXNlY3VyaXNlLnNzaS5nb3V2LmZy
+giJ3d3cubW9uc2VydmljZXNlY3VyaXNlLnNzaS5nb3V2LmZygiR3d3cubW9uc2Vy
+dmljZXNlY3VyaXNlLmN5YmVyLmdvdXYuZnIwPgYDVR0gBDcwNTAzBgZngQwBAgEw
+KTAnBggrBgEFBQcCARYbaHR0cDovL3d3dy5kaWdpY2VydC5jb20vQ1BTMA4GA1Ud
+DwEB/wQEAwIFoDATBgNVHSUEDDAKBggrBgEFBQcDATBlBgNVHR8EXjBcMCygKqAo
+hiZodHRwOi8vY3JsMy5kaWdpY2VydC5jb20vR2FuZGlDZXJ0LmNybDAsoCqgKIYm
+aHR0cDovL2NybDQuZGlnaWNlcnQuY29tL0dhbmRpQ2VydC5jcmwwawYIKwYBBQUH
+AQEEXzBdMCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5kaWdpY2VydC5jb20wNQYI
+KwYBBQUHMAKGKWh0dHA6Ly9jYWNlcnRzLmRpZ2ljZXJ0LmNvbS9HYW5kaUNlcnQu
+Y3J0MAwGA1UdEwEB/wQCMAAwggF+BgorBgEEAdZ5AgQCBIIBbgSCAWoBaAB2AMIx
+fldFGaNF7n843rKQQevHwiFaIr9/1bWtdprZDlLNAAABnJlh3aUAAAQDAEcwRQIh
+ANUSjnmKf1Z0vDEpOVLXmPRO7EBh2iXI3m638R6+JMDdAiBP5UBmCFlpS+uOW7Pm
+dy/J0rjApaY53BaagnA8Gatz+gB2ANdtfRDRp/V3wsfpX9cAv/mCyTNaZeHQswFz
+F8DIxWl3AAABnJlh3ZwAAAQDAEcwRQIhALzTnHGD11soJ+rLoKSUkfRcgYj/6Wk4
+kIrm3XnvqH3JAiBT8zbze4YCXa0zjaNUjDMw3fugcf88UthkTq75GfLImwB2AJRO
+Q4f67MHvgfMZJCaoGGUBx9NfOAIBP3JnfVU3LhnYAAABnJlh3bEAAAQDAEcwRQIg
+FKi32O7jtRtVTLbayoQNm4fbhuUHWLkBA6hSnjYVBuoCIQCNhB9SM4AVyRIe9JTB
+ZtWUrj9zoNcytycTvyzmB4qmwTANBgkqhkiG9w0BAQsFAAOCAgEAo3LxeJLz+zns
+cI5LjCdTCubpJHbwmHPowkazF9w1XmZlq3yX9it9C4s6rwzQo9l5jQHJmD8iysVj
+pOFMSGmsh9sKAn6SOw0JBZfkltSuFd0ihXLoguuof/BIMGMQwIb6KhP+Y5OC2sc4
+Z1bOCSGZaCJQlNItPjHFexgAijSA14uYR+RuktXyKkjHzfVehiZUbLfaom0yEvMJ
+OxJtZE70u/bx9GxAJ27YvA/SZeCFxKiP1zkaYdTjckUBijqL2e+nTCTiDMxSNnjf
+BvJUTThmowZJ9q2Gr6y6i7ZX5uBTrQUJUgeelA4LZ0vlfugUoohlYIplIBtsl2qx
+4R3LF0+YEC9I9PLIl6fkSuEpfLB+PyNwRrM+aQjnyPHgakzAPbvRKSZ834ZkuCek
+LVgCoHc2KnWRSRCizdrSjsqf9/wrYACAHcWSPv9SmR57KU4yxlsnuOQsFJ9TCBe3
+X11H0WoP4LEq/MbNIsGidWzu8gwMSO8AtJttsEpO/sYeL+DbxzXeyPkdwqS64/hb
+4A5qZ62wpRCgLB81CWB3cownVz/XmQ/4Fp7IJROZX3SPA+MWvb6JO2v4EtkVIsPI
+Xq3aPjPpNl9WF7iYVjjszzoizyTyW96+xqUmXihmJ3slf04lc80OOBTzRTnd2dkz
+o/OxTiSEduHQwSb300nlzo1Fiqb281k=
+-----END CERTIFICATE-----
+subject=CN=monservicesecurise.cyber.gouv.fr
+issuer=C=FR, O=Gandi SAS, CN=GandiCert
+---
+No client certificate CA names sent
+Peer signing digest: SHA256
+Peer signature type: rsa_pss_rsae_sha256
+Peer Temp Key: X25519, 253 bits
+---
+SSL handshake has read 3892 bytes and written 1627 bytes
+Verification: OK
+---
+New, TLSv1.3, Cipher is TLS_AES_128_GCM_SHA256
+Protocol: TLSv1.3
+Server public key is 2048 bit
+This TLS version forbids renegotiation.
+Compression: NONE
+Expansion: NONE
+No ALPN negotiated
+Early data was not sent
+Verify return code: 0 (ok)
+---
+---
+Post-Handshake New Session Ticket arrived:
+SSL-Session:
+    Protocol  : TLSv1.3
+    Cipher    : TLS_AES_128_GCM_SHA256
+    Session-ID: DD46B10268A21108A05B12B35C1BAB0F2ED342A49B991A64246662C30E28E258
+    Session-ID-ctx: 
+    Resumption PSK: 53392DBE731D084853FE6041FEBEEF091C845C75739C6DC8A0A0CEF36287E823
+    PSK identity: None
+    PSK identity hint: None
+    SRP username: None
+    TLS session ticket lifetime hint: 604800 (seconds)
+    TLS session ticket:
+    0000 - 91 b7 a5 fe 1d 60 d1 5b-6c 6d 21 86 60 83 33 0b   .....`.[lm!.`.3.
+    0010 - 49 99 56 17 f2 27 9b 0c-eb d5 3b 77 e1 df ff cf   I.V..'....;w....
+    0020 - 08 0d 3b 74 ee 78 1f 1d-cc 7c 08 08 f0 53 a2 c1   ..;t.x...|...S..
+    0030 - 7c 9d b9 10 5d 47 87 75-25 7c ee 0e dd ae 00 83   |...]G.u%|......
+    0040 - 1a b4 70 17 11 14 a3 ed-a8 dc f4 0c 4a 88 0b dd   ..p.........J...
+    0050 - bb 53 b3 da 2d 3c 81 e6-e6 e2 ef 1c 24 38 9b e4   .S..-<......$8..
+    0060 - 77 da 62 5e 4e 9b ba bd-eb                        w.b^N....
+
+    Start Time: 1773224064
+    Timeout   : 7200 (sec)
+    Verify return code: 0 (ok)
+    Extended master secret: no
+    Max Early Data: 0
+---
+read R BLOCK

--- a/check_certificates/tests/test_check
+++ b/check_certificates/tests/test_check
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash_unit
+
+setup() {
+  fake openssl_connect cat ./fixtures/monservicesecurise.cyber.gouv.fr.pem
+}
+
+test_can_get_certificate_validity_for_a_domain() {
+  source ../get_validity
+
+  result=$(get_certificate_validity_for_domain 'foo.com')
+  assert_equals "$result" "26/02/2026 -> 12/09/2026"
+}
+
+test_can_get_certificate_validity_for_several_domains() {
+  source ../get_validity
+
+  result=$(get_certificate_validity_for_domains 'foo.com bar.com baz.com')
+  read -r -d '' expected <<__EOF__
+foo.com 26/02/2026 -> 12/09/2026
+bar.com 26/02/2026 -> 12/09/2026
+baz.com 26/02/2026 -> 12/09/2026
+__EOF__
+
+  assert_equals "$result" "$expected"
+}
+
+test_can_get_the_list_of_certificates_validity_for_each_domain_for_each_service() {
+  assert ../check
+}
+
+# vim: syntax=sh


### PR DESCRIPTION
Nous développons plusieurs services, et certains sont servis via plusieurs domaines (même s'ils sont éventuellement redirigés).

On souhaite pouvoir valider rapidement les dates de validité des certificats sur **TOUS** les domaines que nous couvrons.

Avec ce script, nous obtenons la sortie suivante :
```text
DSC                                                   
demainspecialiste.cyber.gouv.fr       17/12/2025  ->  16/03/2026
www.demainspecialistecyber.fr         17/12/2025  ->  16/03/2026
demainspecialistecyber.fr             17/12/2025  ->  16/03/2026
MAC                                                   
www.monaidecyber.ssi.gouv.fr          26/02/2026  ->  12/09/2026
monaidecyber.ssi.gouv.fr              26/02/2026  ->  12/09/2026
www.monaide.cyber.gouv.fr             26/02/2026  ->  12/09/2026
monaide.cyber.gouv.fr                 26/02/2026  ->  12/09/2026
MSC                                                   
messervices.cyber.gouv.fr             26/02/2026  ->  12/09/2026
MSS                                                   
www.monservicesecurise.ssi.gouv.fr    26/02/2026  ->  12/09/2026
monservicesecurise.ssi.gouv.fr        26/02/2026  ->  12/09/2026
www.monservicesecurise.cyber.gouv.fr  26/02/2026  ->  12/09/2026
monservicesecurise.cyber.gouv.fr      26/02/2026  ->  12/09/2026
NIS2                                                  
www.monespacenis2.cyber.gouv.fr       26/02/2026  ->  12/09/2026
monespacenis2.cyber.gouv.fr           26/02/2026  ->  12/09/2026
```

Qui nous permet d'observer assez rapidement que les domaines de DSC ont un certificat expirant bientôt.