### PR TITLE
Ajoute le provider et les configurations de type et ACL

### DIFF
--- a/export_backup/backup
+++ b/export_backup/backup
@@ -125,6 +125,11 @@ backup_grist() {
   rm "$tmp_dir/db.grist"
 }
 
+configure_rclone() {
+  export RCLONE_CONFIG_TARGET_TYPE=s3
+  export RCLONE_CONFIG_TARGET_ACL=private
+}
+
 rclone_sync_s3() {
   local bucket="$1" ; shift
   export RCLONE_CONFIG_SOURCE_ENDPOINT="$1"
@@ -153,6 +158,8 @@ main() {
   [[ -z "${RCLONE_CONFIG_TARGET_ACCESS_KEY_ID+x}"     ]] && usage "You must define RCLONE_CONFIG_TARGET_ACCESS_KEY_ID"
   [[ -z "${RCLONE_CONFIG_TARGET_SECRET_ACCESS_KEY+x}" ]] && usage "You must define RCLONE_CONFIG_TARGET_ACCESS_KEY_ID"
   [[ -z "${RCLONE_CONFIG_TARGET_ENDPOINT+x}"          ]] && usage "You must define RCLONE_CONFIG_TARGET_ENDPOINT"
+  [[ -z "${RCLONE_CONFIG_TARGET_REGION+x}"            ]] && usage "You must define RCLONE_CONFIG_TARGET_REGION"
+  [[ -z "${RCLONE_CONFIG_TARGET_PROVIDER+x}"          ]] && usage "You must define RCLONE_CONFIG_TARGET_PROVIDER"
   [[ -z "${S3_BUCKETS_TO_BACKUP+x}"                   ]] && usage "You must define S3_BUCKETS_TO_BACKUP"
 
   [[ -z "${GRIST_ID_DOCUMENT+x}" ]] && usage "You must define GRIST_ID_DOCUMENT"
@@ -181,6 +188,8 @@ main() {
   backup_grist
 
   rm -rf "$tmp_dir"
+
+  configure_rclone
 
   for bucket in ${S3_BUCKETS_TO_BACKUP}
   do

--- a/export_backup/tests/test_backup
+++ b/export_backup/tests/test_backup
@@ -26,6 +26,8 @@ setup_backup_script() {
   export RCLONE_CONFIG_TARGET_ACCESS_KEY_ID=mandatory
   export RCLONE_CONFIG_TARGET_SECRET_ACCESS_KEY=mandatory
   export RCLONE_CONFIG_TARGET_ENDPOINT=mandatory
+  export RCLONE_CONFIG_TARGET_REGION=mandatory
+  export RCLONE_CONFIG_TARGET_PROVIDER=mandatory
   export S3_BUCKETS_TO_BACKUP=some-bucket
   export S3_some_bucket_endpoint=mandatory
   export S3_some_bucket_access_key_id=mandatory


### PR DESCRIPTION
... pour la target du `rclone`. Cela permet de s'assurer qu'on utilisera le bon provider au moment du `push` sur la target