### PR TITLE
Fais suivre certaines variables d'environnement

### DIFF
--- a/.github/workflows/export_backup.yml
+++ b/.github/workflows/export_backup.yml
@@ -23,4 +23,6 @@ jobs:
           ID_APP: ${{ secrets.CLEVER_CLOUD_EXPORT_BACKUP_ID_APP }}
         run: |
           clever link "$ID_APP"
+          clever env set CLEVER_SECRET "$CLEVER_SECRET"
+          clever env set CLEVER_TOKEN "$CLEVER_TOKEN"
           clever restart

--- a/.github/workflows/make_backup_deploiement.yml
+++ b/.github/workflows/make_backup_deploiement.yml
@@ -56,4 +56,6 @@ jobs:
           ID_APP: ${{ secrets.CLEVER_CLOUD_MAKE_BACKUP_ID_APP }}
         run: |
           clever link "$ID_APP"
+          clever env set CLEVER_SECRET "$CLEVER_SECRET"
+          clever env set CLEVER_TOKEN "$CLEVER_TOKEN"
           clever deploy --force --same-commit-policy=rebuild


### PR DESCRIPTION
... car le script en a besoin pour s'authentifier auprès de CleverCloud pour avoir accès en lecture aux S3.

Ça évite la duplication (entre l'environnement de CI qui en a besoin pour pouvoir déployer le code, et l'application pour authentifier les lectures) et donc les erreurs lors de la rotation des tokens expirés...