### PR TITLE
Ne fais pas suivre les identifiants lors de `make_backup `

### DIFF
--- a/.github/workflows/make_backup_deploiement.yml
+++ b/.github/workflows/make_backup_deploiement.yml
@@ -56,6 +56,4 @@ jobs:
           ID_APP: ${{ secrets.CLEVER_CLOUD_MAKE_BACKUP_ID_APP }}
         run: |
           clever link "$ID_APP"
-          clever env set CLEVER_SECRET "$CLEVER_SECRET"
-          clever env set CLEVER_TOKEN "$CLEVER_TOKEN"
           clever deploy --force --same-commit-policy=rebuild


### PR DESCRIPTION
... car l'environnement qui fait tourner l'application est distinct de
celui qui héberge les éléments à exporter ; Donc ce ne sont pas les
mêmes identifiants qu'il faut utiliser.